### PR TITLE
Make slug size smaller with conda clean --all (clears caches)

### DIFF
--- a/bin/steps/conda_compile
+++ b/bin/steps/conda_compile
@@ -1,3 +1,5 @@
+conda remove --force btax
+conda remove --force taxcalc
 if [ ! -d /app/.heroku/miniconda ]; then
     puts-step "Preparing Python/Miniconda Environment (3.7.0)"
     curl -Os http://repo.continuum.io/miniconda/Miniconda-3.7.0-Linux-x86_64.sh
@@ -16,5 +18,9 @@ if [ -f requirements.txt ]; then
     pip install --verbose -r requirements.txt  --exists-action=w --allow-all-external | indent
     puts-step "Finished installing dependencies using Pip"
 fi
-
-conda clean -y -pt
+conda remove --force pip
+conda remove --force mock
+conda remove --force pytest
+pip uninstall -y requests-mock
+conda remove --force xlrd
+conda clean -y --all

--- a/bin/steps/conda_compile
+++ b/bin/steps/conda_compile
@@ -18,7 +18,4 @@ if [ -f requirements.txt ]; then
     pip install --verbose -r requirements.txt  --exists-action=w --allow-all-external | indent
     puts-step "Finished installing dependencies using Pip"
 fi
-conda remove --force mock
-conda remove --force pytest
-pip uninstall -y requests-mock
 conda clean -y --all

--- a/bin/steps/conda_compile
+++ b/bin/steps/conda_compile
@@ -21,5 +21,4 @@ fi
 conda remove --force mock
 conda remove --force pytest
 pip uninstall -y requests-mock
-conda remove --force xlrd
 conda clean -y --all

--- a/bin/steps/conda_compile
+++ b/bin/steps/conda_compile
@@ -18,7 +18,6 @@ if [ -f requirements.txt ]; then
     pip install --verbose -r requirements.txt  --exists-action=w --allow-all-external | indent
     puts-step "Finished installing dependencies using Pip"
 fi
-conda remove --force pip
 conda remove --force mock
 conda remove --force pytest
 pip uninstall -y requests-mock


### PR DESCRIPTION
 * This was deployed from my fork about 7 days ago.
 * @brittainhard I'm going to merge this now and do: `heroku buildpacks:set` for our apps to point to this OpenSourcePolicyCenter repo rather than my fork of it.